### PR TITLE
Add support for compiling on Linux

### DIFF
--- a/Include/httpClient/config.h
+++ b/Include/httpClient/config.h
@@ -7,6 +7,7 @@
 #define HC_PLATFORM_XDK 3
 #define HC_PLATFORM_ANDROID 11
 #define HC_PLATFORM_IOS 21
+#define HC_PLATFORM_LINUX 23
 
 // These macros define the datamodels that libHttpClient knows about
 // (a datamodel defines the size of primitive types such as int and pointers)
@@ -46,6 +47,14 @@
     #if TARGET_OS_MAC == 1
         #define HC_PLATFORM HC_PLATFORM_IOS
     #endif
+
+    #if defined(__LP64__)
+        #define HC_DATAMODEL HC_DATAMODEL_LP64
+    #else
+        #define HC_DATAMODEL HC_DATAMODEL_ILP32
+    #endif
+#elif defined(__linux__)
+    #define HC_PLATFORM HC_PLATFORM_LINUX
 
     #if defined(__LP64__)
         #define HC_DATAMODEL HC_DATAMODEL_LP64

--- a/Include/json_cpp/details/asyncrt_utils.h
+++ b/Include/json_cpp/details/asyncrt_utils.h
@@ -28,7 +28,7 @@
 
 #ifndef _WIN32
 #include <boost/algorithm/string.hpp>
-#if !defined(ANDROID) && !defined(__ANDROID__) // CodePlex 269
+#if !defined(__linux__) && !defined(ANDROID) && !defined(__ANDROID__) // CodePlex 269
 #include <xlocale.h>
 #endif
 #endif

--- a/Source/Common/uri.cpp
+++ b/Source/Common/uri.cpp
@@ -4,6 +4,8 @@
 #include "pch.h"
 #include "uri.h"
 
+#include <algorithm>
+
 NAMESPACE_XBOX_HTTP_CLIENT_BEGIN
 
 void AppendPortToString(String& string, uint16_t port);

--- a/Source/Common/utils.cpp
+++ b/Source/Common/utils.cpp
@@ -3,6 +3,8 @@
 
 #include "pch.h"
 
+#include <algorithm>
+
 NAMESPACE_XBOX_HTTP_CLIENT_BEGIN
 
 static void ltrim_whitespace(_In_ http_internal_wstring& str)

--- a/Source/Common/utils.h
+++ b/Source/Common/utils.h
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include <cstdarg>
 #include <string.h>
 
 using String = http_internal_string;

--- a/Source/HTTP/httpcall.cpp
+++ b/Source/HTTP/httpcall.cpp
@@ -5,6 +5,8 @@
 #include "httpcall.h"
 #include "../Mock/mock.h"
 
+#include <cmath>
+
 using namespace xbox::httpclient;
 
 const int MIN_DELAY_FOR_HTTP_INTERNAL_ERROR_IN_MS = 10000;


### PR DESCRIPTION
This change makes surgical edits to accommodate Linux builds - adding to config.h - and adds `#includes` necessary for GCC 7.0 compilation on Ubuntu 18.04.

